### PR TITLE
Update Makefile to allow for a compiler override via CC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@ GCCPATH=/usr
 
 NVCC=${CUDAPATH}/bin/nvcc
 CCPATH=${GCCPATH}/bin
+CC=g++
 
 drv:
-	PATH=${PATH}:.:${CCPATH}:${PATH} ${NVCC} -I${CUDAPATH}/include -arch=compute_30 -ptx compare.cu -o compare.ptx
-	g++ -O3 -Wno-unused-result -I${CUDAPATH}/include -c gpu_burn-drv.cpp
-	g++ -o gpu_burn gpu_burn-drv.o -O3 -lcuda -L${CUDAPATH}/lib64 -L${CUDAPATH}/lib -Wl,-rpath=${CUDAPATH}/lib64 -Wl,-rpath=${CUDAPATH}/lib -lcublas -lcudart -o gpu_burn
+	PATH=${PATH}:.:${CCPATH}:${PATH} ${NVCC} -ccbin ${CC} -I${CUDAPATH}/include -arch=compute_30 -ptx compare.cu -o compare.ptx
+	${CC} -O3 -Wno-unused-result -I${CUDAPATH}/include -c gpu_burn-drv.cpp
+	${CC} -o gpu_burn gpu_burn-drv.o -O3 -lcuda -L${CUDAPATH}/lib64 -L${CUDAPATH}/lib -Wl,-rpath=${CUDAPATH}/lib64 -Wl,-rpath=${CUDAPATH}/lib -lcublas -lcudart -o gpu_burn


### PR DESCRIPTION
This commit allows for a compiler override like `make CC=g++-7`. Newer distros like Ubuntu 19.10 default to GCC 9 and will fail to build without a compiler override.

I tested it when _g++_ symlinks to _g++-7_ and plain `make` is called, and it still works.