### PR TITLE
Makefile: Allow to override CUDAPATH with custom location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CUDAPATH=/usr/local/cuda
+CUDAPATH ?= /usr/local/cuda
 
 # Have this point to an old enough gcc (for nvcc)
 GCCPATH=/usr


### PR DESCRIPTION
CUDA might not always be installed in /usr/local/cuda but in a custom
path. As such allow to override the default by setting CUDAPATH in the
environment.

Signed-off-by: Salvatore Bonaccorso <bonaccos@ee.ethz.ch>