### PR TITLE
Allow CUDAPATH to be provided on command line.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CUDAPATH=/usr/local/cuda
+CUDAPATH?=/usr/local/cuda
 
 # Have this point to an old enough gcc (for nvcc)
 GCCPATH=/usr


### PR DESCRIPTION
In our environment (Ubuntu 18.04), `nvcc` is found at `/usr/bin/nvcc`, which means one would like to at least be able to override `CUDAPATH`, as in:

    CUDAPATH=/usr make

Trivial fix.