### PR TITLE
add Makefile dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,14 @@ GCCPATH=/usr
 NVCC=${CUDAPATH}/bin/nvcc
 CCPATH=${GCCPATH}/bin
 
-drv:
+default: gpu_burn
+
+compare.ptx: compare.cu
 	PATH=${PATH}:.:${CCPATH}:${PATH} ${NVCC} -I${CUDAPATH}/include -arch=compute_50 -ptx compare.cu -o compare.ptx
+
+gpu_burn: gpu_burn-drv.cpp compare.ptx
 	g++ -O3 -Wno-unused-result -I${CUDAPATH}/include -c gpu_burn-drv.cpp
 	g++ -o gpu_burn gpu_burn-drv.o -O3 -lcuda -L${CUDAPATH}/lib64 -L${CUDAPATH}/lib -Wl,-rpath=${CUDAPATH}/lib64 -Wl,-rpath=${CUDAPATH}/lib -lcublas -lcudart -o gpu_burn
+
+clean:
+	git clean -fX

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CUDAPATH=/usr/local/cuda
+CUDAPATH?=/usr/local/cuda
 
 # Have this point to an old enough gcc (for nvcc)
 GCCPATH=/usr


### PR DESCRIPTION
These changes add some (simplistic) dependencies to the makefile so that subsequent builds only build if necessary.   While minimal, this helps where (in our case) deployment and testing occurs by automation (in our case, Ansible).

Builds upon previous PR (https://github.com/wilicc/gpu-burn/pull/29)