### PR TITLE
Parameterize the Docker build to allow setting CUDA and Base versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM nvidia/cuda:11.1.1-devel AS builder
+ARG CUDA_VERSION=11.8.0
+ARG IMAGE_DISTRO=ubi8
+
+FROM nvidia/cuda:${CUDA_VERSION}-devel-${IMAGE_DISTRO} AS builder
 
 WORKDIR /build
 
@@ -6,7 +9,7 @@ COPY . /build/
 
 RUN make
 
-FROM nvidia/cuda:11.1.1-runtime
+FROM nvidia/cuda:${CUDA_VERSION}-runtime-${IMAGE_DISTRO}
 
 COPY --from=builder /build/gpu_burn /app/
 COPY --from=builder /build/compare.ptx /app/

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,15 @@ LDFLAGS  += -Wl,-rpath=${CUDAPATH}/lib
 LDFLAGS  += -lcublas
 LDFLAGS  += -lcudart
 
-COMPUTE   ?= 50
+COMPUTE      ?= 50
+CUDA_VERSION ?= 11.8.0
+IMAGE_DISTRO ?= ubi8
 
 NVCCFLAGS ?=
 NVCCFLAGS += -I${CUDAPATH}/include
 NVCCFLAGS += -arch=compute_$(subst .,,${COMPUTE})
+
+IMAGE_NAME ?= gpu-burn
 
 .PHONY: clean
 
@@ -38,4 +42,4 @@ clean:
 	$(RM) *.ptx *.o gpu_burn
 
 image:
-	docker build -t gpu-burn .
+	docker build --build-arg CUDA_VERSION=${CUDA_VERSION} --build-arg IMAGE_DISTRO=${IMAGE_DISTRO} -t ${IMAGE_NAME} .

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ CCPATH can be specified to point to a specific gcc (default is
 
 `make CCPATH=/usr/local/bin`
 
+CUDA_VERSION and IMAGE_DISTRO can be used to override the base
+images used when building the Docker `image` target, while IMAGE_NAME
+can be set to change the resulting image tag:
+
+`make IMAGE_NAME=myregistry.private.com/gpu-burn CUDA_VERSION=12.0.1 IMAGE_DISTRO=ubuntu22.04 image`
+
 # Usage
 
     GPU Burn


### PR DESCRIPTION
- Make the CUDA version and base image distro configurable by the person building a Docker image.
- Allow overriding the target image name via Make as well.
- Upgrade the default CUDA version in images to 11.8.0 from 11.1.1