### PR TITLE
Update gpu_burn-drv.cpp

### DIFF
--- a/gpu_burn-drv.cpp
+++ b/gpu_burn-drv.cpp
@@ -732,7 +732,7 @@ void launch(int runLength, bool useDoubles, bool useTensorCores,
 
             if (!devCount) {
                 fprintf(stderr, "No CUDA devices\n");
-                exit(EXIT_FAILURE);
+                exit(ENODEV);
             } else {
                 for (int i = 1; i < devCount; ++i) {
                     int slavePipe[2];
@@ -856,11 +856,11 @@ int main(int argc, char **argv) {
                 useBytes = decodeUSEMEM(argv[i]);
             } else {
                 fprintf(stderr, "Syntax error near -m\n");
-                exit(EXIT_FAILURE);
+                exit(EINVAL);
             }
             if (useBytes == 0) {
                 fprintf(stderr, "Syntax error near -m\n");
-                exit(EXIT_FAILURE);
+                exit(EINVAL);
             }
         }
         if (argc >= 2 && strncmp(argv[i], "-i", 2) == 0) {
@@ -874,7 +874,7 @@ int main(int argc, char **argv) {
                 device_id = strtol(argv[i], NULL, 0);
             } else {
                 fprintf(stderr, "Syntax error near -i\n");
-                exit(EXIT_FAILURE);
+                exit(EINVAL);
             }
         }
         if (argc >= 2 && strncmp(argv[i], "-c", 2) == 0) {


### PR DESCRIPTION
Updating the error / exit code handling. Instead of exiting with `EXIT_FAILURE` for not having CUDA Device, exit with `ENODEV` which represent no device (since no GPU is found).
For exits causes by invalid argument parsing, updating from `EXIT_FAILURE` to `EINVAL` which is invalid argument. 
These changes makes it hard to track when GPU fails (can translate exit code to issue more quickly).