### PR TITLE
fix build error under WSL2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ gpu_burn: gpu_burn-drv.o compare.ptx
 	g++ ${CFLAGS} -c $<
 
 %.ptx: %.cu
-	$PATH=${PATH}:${CCPATH}:. ${NVCC} ${NVCCFLAGS} -ptx $< -o $@
+	PATH="${PATH}:${CCPATH}:." ${NVCC} ${NVCCFLAGS} -ptx $< -o $@
 
 clean:
 	$(RM) *.ptx *.o gpu_burn


### PR DESCRIPTION
the environment variable `PATH` may contain spaces