### PR TITLE
Fix to_string compilation issues for older versions of g++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ CFLAGS   ?=
 CFLAGS   += -O3
 CFLAGS   += -Wno-unused-result
 CFLAGS   += -I${CUDAPATH}/include
+CFLAGS   += -std=c++11
 
 LDFLAGS  ?=
 LDFLAGS  += -lcuda


### PR DESCRIPTION
On CentOS 7 `make` fails with the following error message:

```
In file included from /usr/include/c++/4.8.2/chrono:35:0,
                 from gpu_burn-drv.cpp:41:
/usr/include/c++/4.8.2/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support for the \
  ^
gpu_burn-drv.cpp: In function 'void _checkError(int, std::string, int, std::string)':
gpu_burn-drv.cpp:74:26: error: 'to_string' is not a member of 'std'
             file + ":" + std::to_string(line) + "): " + err);
                          ^
```
Fix this by explicitly adding the `-std=c++11` flag to the Makefile.

Closes: https://github.com/wilicc/gpu-burn/issues/79