### PR TITLE
Allow to append to CFLAGS, LDFLAGS and NVCCFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,27 +3,27 @@ CUDAPATH ?= /usr/local/cuda
 NVCC     :=  ${CUDAPATH}/bin/nvcc
 CCPATH   ?=
 
-CFLAGS   ?=
-CFLAGS   += -O3
-CFLAGS   += -Wno-unused-result
-CFLAGS   += -I${CUDAPATH}/include
+override CFLAGS   ?=
+override CFLAGS   += -O3
+override CFLAGS   += -Wno-unused-result
+override CFLAGS   += -I${CUDAPATH}/include
 
-LDFLAGS  ?=
-LDFLAGS  += -lcuda
-LDFLAGS  += -L${CUDAPATH}/lib64
-LDFLAGS  += -L${CUDAPATH}/lib
-LDFLAGS  += -Wl,-rpath=${CUDAPATH}/lib64
-LDFLAGS  += -Wl,-rpath=${CUDAPATH}/lib
-LDFLAGS  += -lcublas
-LDFLAGS  += -lcudart
+override LDFLAGS  ?=
+override LDFLAGS  += -lcuda
+override LDFLAGS  += -L${CUDAPATH}/lib64
+override LDFLAGS  += -L${CUDAPATH}/lib
+override LDFLAGS  += -Wl,-rpath=${CUDAPATH}/lib64
+override LDFLAGS  += -Wl,-rpath=${CUDAPATH}/lib
+override LDFLAGS  += -lcublas
+override LDFLAGS  += -lcudart
 
 COMPUTE      ?= 50
 CUDA_VERSION ?= 11.8.0
 IMAGE_DISTRO ?= ubi8
 
-NVCCFLAGS ?=
-NVCCFLAGS += -I${CUDAPATH}/include
-NVCCFLAGS += -arch=compute_$(subst .,,${COMPUTE})
+override NVCCFLAGS ?=
+override NVCCFLAGS += -I${CUDAPATH}/include
+override NVCCFLAGS += -arch=compute_$(subst .,,${COMPUTE})
 
 IMAGE_NAME ?= gpu-burn
 


### PR DESCRIPTION
Currently, `make CFLAGS=<new-flags>` overrides any values of CFLAGS set in the Makefile and will result in an error referring to missing headers:

```
$ make CFLAGS=-std=c++11
g++ -std=c++11 -c gpu_burn-drv.cpp
gpu_burn-drv.cpp:61:23: fatal error: cublas_v2.h: No such file or directory
 #include "cublas_v2.h"
                       ^
compilation terminated.
make: *** [gpu_burn-drv.o] Error 1
```
This change adds the "override" directive
(https://www.gnu.org/software/make/manual/make.html#Override-Directive) to all Makefile variables specified as appendable in the README.