### PR TITLE
add stubs to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ CFLAGS   += -I${CUDAPATH}/include
 LDFLAGS  ?=
 LDFLAGS  += -lcuda
 LDFLAGS  += -L${CUDAPATH}/lib64
+LDFLAGS  += -L${CUDAPATH}/lib64/stubs
 LDFLAGS  += -L${CUDAPATH}/lib
+LDFLAGS  += -L${CUDAPATH}/lib/stubs
 LDFLAGS  += -Wl,-rpath=${CUDAPATH}/lib64
 LDFLAGS  += -Wl,-rpath=${CUDAPATH}/lib
 LDFLAGS  += -lcublas


### PR DESCRIPTION
adding stubs to LDFLAGS. This was needed when trying to build gpu_burn for cuda12.0 toolkit after installing from the `.run` file on [nvidia's website](https://developer.nvidia.com/cuda-toolkit-archive).

# Test Plan

```bash
$ make CUDAPATH=$CUDA_HOME
$ ./gpu_burn
done

Tested 2 GPUs:
        GPU 0: OK
        GPU 1: OK
```