### PR TITLE
Add support for Jetson devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,16 @@ else ifneq ("$(wildcard /usr/local/cuda/bin/nvcc)", "")
 CUDAPATH ?= /usr/local/cuda
 endif
 
-NVCC     :=  ${CUDAPATH}/bin/nvcc
-CCPATH   ?=
+IS_JETSON   ?= $(shell if grep -Fwq "Jetson" /proc/device-tree/model 2>/dev/null; then echo true; else echo false; fi)
+NVCC        :=  ${CUDAPATH}/bin/nvcc
+CCPATH      ?=
 
 override CFLAGS   ?=
 override CFLAGS   += -O3
 override CFLAGS   += -Wno-unused-result
 override CFLAGS   += -I${CUDAPATH}/include
 override CFLAGS   += -std=c++11
+override CFLAGS   += -DIS_JETSON=${IS_JETSON}
 
 override LDFLAGS  ?=
 override LDFLAGS  += -lcuda


### PR DESCRIPTION
Adds support for Jetson devices. The kind of device is detected at compile time and if it's a Jetson, `nvidia-smi` is replaced by `tegrastats`. Relates to: #66.

Tested on Jetson Xavier NX with JetPack 5.1.2 but it should work on all Jetsons since they all have `tegrastats` built in, as far as I know.

![burn](https://github.com/wilicc/gpu-burn/assets/91887911/d2eb8dc7-2f02-4370-83d3-a066a8df25c9)

![jtop](https://github.com/wilicc/gpu-burn/assets/91887911/d1a9757d-7efa-4c0d-b6c0-9af8a2973804)

 