### PR TITLE
Add cuDeviceGetProperties and fix readme usage info

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,12 @@ can be set to change the resulting image tag:
     -tc    Try to use Tensor cores (if available)
     -l     List all GPUs in the system
     -i N   Execute only on GPU N
+    -c FILE Use FILE as compare kernel.  Default is compare.ptx
+    -stts T Set timeout threshold to T seconds for using SIGTERM to abort child processes before using SIGKILL.  Default is 30
     -h     Show this help message
-    
+
     Example:
-    gpu_burn -d 3600
+    gpu-burn -d 3600 # burns all GPUs with doubles for an hour
+    gpu-burn -m 50% # burns using 50% of the available GPU memory
+    gpu-burn -l # list GPUs
+    gpu-burn -i 2 # burns only GPU of index 2

--- a/gpu_burn-drv.cpp
+++ b/gpu_burn-drv.cpp
@@ -785,6 +785,21 @@ void showHelp() {
     printf("  gpu-burn -i 2 # burns only GPU of index 2\n");
 }
 
+void showProp(CUdevprop device_p) {
+    printf("Total amount of constant memory: %d bytes\n", device_p.totalConstantMemory);
+    printf("Total amount of shared memory per block: %d bytes\n", device_p.sharedMemPerBlock);
+    printf("Total number of registers available per block: %d\n", device_p.regsPerBlock);
+    printf("Maximum number of threads per block: %d\n", device_p.maxThreadsPerBlock);
+    printf("Max dimension size of a thread block (x,y,z): (%d, %d, %d)\n",
+           device_p.maxThreadsDim[0], device_p.maxThreadsDim[1], device_p.maxThreadsDim[2]);
+    printf("Max dimension size of a grid size (x,y,z): (%d, %d, %d)\n",
+           device_p.maxGridSize[0], device_p.maxGridSize[1], device_p.maxGridSize[2]);
+    printf("Maximum memory pitch: %d bytes\n", device_p.memPitch);
+    printf("Texture alignment: %d bytes\n", device_p.textureAlign);
+    printf("SIMD width: %d\n", device_p.SIMDWidth);
+    printf("Clock rate: %d MHz\n", device_p.clockRate / 1000);
+}
+
 // NNN MB
 // NN% <0
 // 0 --- error
@@ -821,13 +836,16 @@ int main(int argc, char **argv) {
             }
             for (int i_dev = 0; i_dev < count; i_dev++) {
                 CUdevice device_l;
+                CUdevprop device_p;
                 char device_name[255];
                 checkError(cuDeviceGet(&device_l, i_dev));
                 checkError(cuDeviceGetName(device_name, 255, device_l));
+                checkError(cuDeviceGetProperties(&device_p, device_l))
                 size_t device_mem_l;
                 checkError(cuDeviceTotalMem(&device_mem_l, device_l));
                 printf("ID %i: %s, %ldMB\n", i_dev, device_name,
                        device_mem_l / 1000 / 1000);
+                showProp(device_p);
             }
             thisParam++;
             return 0;


### PR DESCRIPTION
1）Add cuDeviceGetProperties to show device properties when execute the cmd gpu_burn -l;
2）Fix README.md usage info，add example to match the cmd gpu_burn -h;

Test Result:
1）./gpu_burn -l
ID 0: Xavier, 32508MB
Total amount of constant memory: 65536 bytes
Total amount of shared memory per block: 49152 bytes
Total number of registers available per block: 65536
Maximum number of threads per block: 1024
Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
Max dimension size of a grid size (x,y,z): (2147483647, 65535, 65535)
Maximum memory pitch: 2147483647 bytes
Texture alignment: 512 bytes
SIMD width: 32
Clock rate: 1377 MHz

2）fix README.md
GPU Burn
Usage: gpu_burn [OPTIONS] [TIME]

-m X   Use X MB of memory
-m N%  Use N% of the available GPU memory
-d     Use doubles
-tc    Try to use Tensor cores (if available)
-l     List all GPUs in the system
-i N   Execute only on GPU N
-c FILE Use FILE as compare kernel.  Default is compare.ptx
-stts T Set timeout threshold to T seconds for using SIGTERM to abort child processes before using SIGKILL.  Default is 30
-h     Show this help message

Example:
gpu-burn -d 3600 # burns all GPUs with doubles for an hour
gpu-burn -m 50% # burns using 50% of the available GPU memory
gpu-burn -l # list GPUs
gpu-burn -i 2 # burns only GPU of index 2