### PR TITLE
Free memory allocated for faultyElemData

### DIFF
--- a/gpu_burn-drv.cpp
+++ b/gpu_burn-drv.cpp
@@ -135,6 +135,7 @@ template <class T> class GPU_Test {
         checkError(cuMemFree(d_Cdata), "Free A");
         checkError(cuMemFree(d_Adata), "Free B");
         checkError(cuMemFree(d_Bdata), "Free C");
+        checkError(cuMemFree(d_faultyElemData), "Free faulty data");
         cuMemFreeHost(d_faultyElemsHost);
         printf("Freed memory for dev %d\n", d_devNumber);
 


### PR DESCRIPTION
- memory allocated at: `checkError(cuMemAlloc(&d_faultyElemData, sizeof(int)), "faulty data");` is never freed.
- Added `checkError(cuMemFree(d_faultyElemData), "Free faulty data");` to `~GPU_Test`