### PR TITLE
Informative error if memory to burn is less than threshold

### DIFF
--- a/cube_code.scad
+++ b/cube_code.scad
@@ -1,0 +1,73 @@
+// Units in inches
+inch = 25.4;
+
+// Dimensions
+cube_length = 7 * inch;    // X
+cube_breadth = 7 * inch;   // Z
+cube_height = 1 * inch;    // Y
+
+cyl_outer_d = 1 * inch;
+cyl_inner_d = 0.5 * inch;
+cyl_height = 2 * inch;
+
+$fn = 100; // smooth curves
+
+// Base cube
+cube([cube_length, cube_height, cube_breadth]);
+
+// First cylinder (top) - now correctly attached to left face (X=0)
+translate([-7, cube_height /2 , cube_breadth - cyl_outer_d -29])
+    rotate([0, 0, 90])
+    difference() {
+        cylinder(h = cyl_height, d = cyl_outer_d, center = false);
+        translate([0, 0, -1])
+            cylinder(h = cyl_height + 2, d = cyl_inner_d, center = false);
+    }
+
+// Second cylinder (bottom) - also attached to left face
+translate([-7, cube_height / 2, cyl_outer_d /2 -10])
+    rotate([0, 0, 90])
+    difference() {
+        cylinder(h = cyl_height, d = cyl_outer_d, center = false);
+        translate([0, 0, -1])
+            cylinder(h = cyl_height + 2, d = cyl_inner_d, center = false);
+    }
+
+// === RIGHT FACE CYLINDER ===
+// Third cylinder (center-right)
+translate([cube_length+7, cube_height/2, cube_breadth -120])
+    rotate([0, 0, 90])
+    difference() {
+        cylinder(h = cyl_height, d = cyl_outer_d, center = false);
+        translate([0, 0, -1])
+            cylinder(h = cyl_height + 2, d = cyl_inner_d, center = false);
+    }
+
+// === TOP FACE CYLINDERS ===
+// Fourth cylinder (top face, left side)
+translate([cyl_outer_d /2 - 7, cube_height /2, cube_breadth+ 7])
+    rotate([0, 90, 0])
+    difference() {
+        cylinder(h = cyl_height, d = cyl_outer_d, center = false);
+        translate([0, 0, -1])
+            cylinder(h = cyl_height + 2, d = cyl_inner_d, center = false);
+    }
+
+// Fifth cylinder (top face, right side)
+translate([cube_length - cyl_outer_d / 2 - 41, cube_height/2, cube_breadth + 7])
+    rotate([0, 90, 0])
+    difference() {
+        cylinder(h = cyl_height, d = cyl_outer_d, center = false);
+        translate([0, 0, -1])
+            cylinder(h = cyl_height + 2, d = cyl_inner_d, center = false);
+    }
+
+
+// === BOTTOM FACE CYLINDER (centered) ===
+translate([cube_length / 2 - cyl_height / 2 , cube_height / 2, cube_breadth / 2 - cube_length / 2 -7])
+    rotate([0, 90, 0])
+    difference() {
+        cylinder(h = cyl_height, d = cyl_outer_d, center = false);
+        translate([0, 0, -1])
+            cylinder(h = cyl_height + 2, d = cyl_inner_d, center = false);
+    }

--- a/gpu_burn-drv.cpp
+++ b/gpu_burn-drv.cpp
@@ -190,8 +190,11 @@ template <class T> class GPU_Test {
                   d_resultSize; // We remove A and B sizes
         printf("Results are %zu bytes each, thus performing %zu iterations\n",
                d_resultSize, d_iters);
-        if ((size_t)useBytes < 3 * d_resultSize)
+        if ((size_t)useBytes < 3 * d_resultSize) {
+            printf("Provided bytes (%lu MB) are not sufficient. aborting.\n",
+                    useBytes / 1024ul / 1024ul);
             throw std::string("Low mem for result. aborting.\n");
+        }
         checkError(cuMemAlloc(&d_Cdata, d_iters * d_resultSize), "C alloc");
         checkError(cuMemAlloc(&d_Adata, d_resultSize), "A alloc");
         checkError(cuMemAlloc(&d_Bdata, d_resultSize), "B alloc");

--- a/pin.scad
+++ b/pin.scad
@@ -1,0 +1,48 @@
+// Units in inches
+inch = 25.4;
+
+// Pin dimensions
+pin_diameter = 0.5 * inch;
+pin_length = 6.5 * inch;
+
+// Head dimensions
+head_diameter = 0.75 * inch;
+head_height = 0.2 * inch;
+
+$fn = 100; // smooth cylinder resolution
+
+// Final pin with head
+union() {
+    // Pin body
+    cylinder(h = pin_length, d = pin_diameter, center = false);
+    
+    // Head on top
+    translate([0, 0, pin_length])
+        cylinder(h = head_height, d = head_diameter, center = false);
+B
+B
+B
+B
+B
+B
+B
+B
+B
+B
+B
+B
+B
+B
+A
+A
+A
+A
+A
+A
+A
+A
+A
+A
+A
+A
+}

--- a/pin.scad
+++ b/pin.scad
@@ -19,30 +19,4 @@ union() {
     // Head on top
     translate([0, 0, pin_length])
         cylinder(h = head_height, d = head_diameter, center = false);
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
-A
-A
-A
-A
-A
-A
-A
-A
-A
-A
-A
-A
 }


### PR DESCRIPTION
[Problem]
If the %age memory to burn is below a threshold then program aborts without any user friendly message.

[Solution]
Added a user friendly message that can save debugging for the user

[Testing]
Testing with following run
```
ashuthak@ashuthak-ubuntu:~/gpu_burn/gpu-burn$ ./gpu_burn -m 1% 60
Using compare file: compare.ptx
Burning for 60 seconds.
GPU 0: NVIDIA GeForce RTX 4060 Laptop GPU (UUID: GPU-062ffaaa-3ab3-31f9-1938-451fee6a15fb)
Initialized device 0 with 7721 MB of memory (7594 MB available, using 75 MB of it), using FLOATS
Results are 268435456 bytes each, thus performing 68719476734 iterations
Provide bytes (75 MB) are not sufficient. aborting.
terminate called after throwing an instance of 'std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >'
1.7%  proc'd: -1 (0 Gflop/s)   errors: 0  (DIED!)  temps: 49 C
```