### PR TITLE
Update CUDA Context Creation for CUDA 13

### DIFF
--- a/gpu_burn-drv.cpp
+++ b/gpu_burn-drv.cpp
@@ -110,7 +110,12 @@ template <class T> class GPU_Test {
     GPU_Test(int dev, bool doubles, bool tensors, const char *kernelFile)
         : d_devNumber(dev), d_doubles(doubles), d_tensors(tensors), d_kernelFile(kernelFile){
         checkError(cuDeviceGet(&d_dev, d_devNumber));
+#if CUDA_VERSION >= 13000
+        CUctxCreateParams ctxCreateParams = {};
+        checkError(cuCtxCreate(&d_ctx, &ctxCreateParams, 0, d_dev));
+#else
         checkError(cuCtxCreate(&d_ctx, 0, d_dev));
+#endif
 
         bind();
 


### PR DESCRIPTION
This commit checks at compile time if we are using CUDA 13 headers and will link to CUDA 13, at which point we need to use a different function signature for `cuCreateCtx` as it changed in CUDA 13 (it added a parameter).

For CUDA versions below 13, we continue using the old function signature (a 3 parameter version).

This compiles and runs on my CUDA 13 system.  I have not directly tested this with CUDA 12 and below yet.