### PR TITLE
add transparent amd gpu support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-
+*.o
 gpu_burn-drv\.o
-
 compare\.ptx
-
 gpu_burn
+gpu_burn_hip
+*_hip.cpp

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
-ifneq ("$(wildcard /usr/bin/nvcc)", "")
-CUDAPATH ?= /usr
+TARGET := NVIDIA
+# TARGET := AMD
+
+ifneq ("$(wildcard /opt/cuda/bin/nvcc)", "")
+CUDAPATH ?= /opt/cuda
 else ifneq ("$(wildcard /usr/local/cuda/bin/nvcc)", "")
 CUDAPATH ?= /usr/local/cuda
 endif
@@ -7,15 +10,28 @@ endif
 IS_JETSON   ?= $(shell if grep -Fwq "Jetson" /proc/device-tree/model 2>/dev/null; then echo true; else echo false; fi)
 NVCC        :=  ${CUDAPATH}/bin/nvcc
 CCPATH      ?=
+ROCM_PATH   := /opt/rocm
 
 override CFLAGS   ?=
 override CFLAGS   += -O3
 override CFLAGS   += -Wno-unused-result
-override CFLAGS   += -I${CUDAPATH}/include
 override CFLAGS   += -std=c++11
+
+ifeq ($(TARGET),NVIDIA)
+override CFLAGS += -D__TARGET_NVIDIA
+endif
+ifeq ($(TARGET),AMD)
+override CFLAGS += -D__TARGET_AMD
+endif
+
+ifeq ($(TARGET),NVIDIA)
+override CFLAGS   += -I${CUDAPATH}/include
 override CFLAGS   += -DIS_JETSON=${IS_JETSON}
+endif
 
 override LDFLAGS  ?=
+
+ifeq ($(TARGET),NVIDIA)
 override LDFLAGS  += -lcuda
 override LDFLAGS  += -L${CUDAPATH}/lib64
 override LDFLAGS  += -L${CUDAPATH}/lib64/stubs
@@ -25,6 +41,14 @@ override LDFLAGS  += -Wl,-rpath=${CUDAPATH}/lib64
 override LDFLAGS  += -Wl,-rpath=${CUDAPATH}/lib
 override LDFLAGS  += -lcublas
 override LDFLAGS  += -lcudart
+endif
+
+ifeq ($(TARGET),AMD)
+override LDFLAGS  += -Wl,-rpath=$(ROCM_PATH)/lib -lhipblas
+override CFLAGS += -I$(ROCM_PATH)/include
+override CFLAGS += -I$(ROCM_PATH)/include/hipblas
+override CFLAGS += -D__HIP_PLATFORM_AMD__
+endif
 
 COMPUTE      ?= 75
 CUDA_VERSION ?= 11.8.0
@@ -38,6 +62,29 @@ IMAGE_NAME ?= gpu-burn
 
 .PHONY: clean
 
+ifeq ($(TARGET),AMD)
+
+all: gpu_burn_hip compare.o
+
+gpu_burn_hip: gpu_burn-drv_hip.o
+	hipcc $(CFLAGS) $^ $(LDFLAGS) -o $@
+
+%.hip: %.cu
+	hipify-perl $< -o $@
+
+gpu_burn-drv_hip.cpp: gpu_burn-drv.cpp
+	hipify-perl $< -o $@
+
+%.o: %.hip
+	hipcc --genco $(CFLAGS) $< -o $@
+
+%.o: %.cpp
+	hipcc ${CFLAGS} -c $<
+
+endif # TARGET AMD
+
+ifeq ($(TARGET),NVIDIA)
+
 gpu_burn: gpu_burn-drv.o compare.ptx
 	g++ -o $@ $< -O3 ${LDFLAGS}
 
@@ -47,8 +94,10 @@ gpu_burn: gpu_burn-drv.o compare.ptx
 %.ptx: %.cu
 	PATH="${PATH}:${CCPATH}:." ${NVCC} ${NVCCFLAGS} -ptx $< -o $@
 
+endif # TARGET NVIDIA
+
 clean:
-	$(RM) *.ptx *.o gpu_burn
+	$(RM) *.hip *.ptx *.o gpu_burn gpu_burn_hip
 
 image:
 	docker build --build-arg CUDA_VERSION=${CUDA_VERSION} --build-arg IMAGE_DISTRO=${IMAGE_DISTRO} -t ${IMAGE_NAME} .

--- a/gpu_burn-drv.cpp
+++ b/gpu_burn-drv.cpp
@@ -30,7 +30,14 @@
 // Matrices are SIZE*SIZE..  POT should be efficiently implemented in CUBLAS
 #define SIZE 8192ul
 #define USEMEM 0.9 // Try to allocate 90% of memory
+		   //
+#if defined(__TARGET_NVIDIA)
 #define COMPARE_KERNEL "compare.ptx"
+#elif defined(__TARGET_AMD)
+#define COMPARE_KERNEL "compare.o"
+#else
+#error "Either __TARGET_NVIDIA or __TARGET_AMD must be defined!"
+#endif
 
 // Used to report op/s, measured through Visual Profiler, CUBLAS from CUDA 7.5
 // (Seems that they indeed take the naive dim^3 approach)
@@ -245,8 +252,12 @@ template <class T> class GPU_Test {
                                        d_doubles ? "compareD" : "compare"),
                    "get func");
 
+#if defined(__TARGET_NVIDIA)
+// NOTE:
+// * this function is available in hip, but it is not converted by hipify-perl ?
         checkError(cuFuncSetCacheConfig(d_function, CU_FUNC_CACHE_PREFER_L1),
                    "L1 config");
+
         checkError(cuParamSetSize(d_function, __alignof(T *) +
                                                   __alignof(int *) +
                                                   __alignof(size_t)),
@@ -262,13 +273,16 @@ template <class T> class GPU_Test {
 
         checkError(cuFuncSetBlockShape(d_function, g_blockSize, g_blockSize, 1),
                    "set block size");
+#endif // __TARGET_NVIDIA
     }
 
     void compare() {
         checkError(cuMemsetD32Async(d_faultyElemData, 0, 1, 0), "memset");
+#if defined(__TARGET_NVIDIA)
         checkError(cuLaunchGridAsync(d_function, SIZE / g_blockSize,
                                      SIZE / g_blockSize, 0),
                    "Launch grid");
+#endif // __TARGET_NVIDIA	
         checkError(cuMemcpyDtoHAsync(d_faultyElemsHost, d_faultyElemData,
                                      sizeof(int), 0),
                    "Read faultyelemdata");
@@ -534,8 +548,13 @@ void listenClients(std::vector<int> clientFd, std::vector<pid_t> clientPid,
                 childReport = true;
             }
 
+#if defined(__TARGET_NVIDIA)
+	// TODO: fix temps for AMD
+	// if nvidia-smi is not available, this currently leads to a segmentation 
+	// fault on AMD cards
         if (FD_ISSET(tempHandle, &waitHandles))
             updateTemps(tempHandle, &clientTemp);
+#endif
 
         // Resetting the listeners
         FD_ZERO(&waitHandles);
@@ -667,6 +686,7 @@ template <class T>
 void launch(int runLength, bool useDoubles, bool useTensorCores,
             ssize_t useBytes, int device_id, const char * kernelFile,
             std::chrono::seconds sigterm_timeout_threshold_secs) {
+#if defined(__TARGET_NVIDIA)
 #if IS_JETSON
     std::ifstream f_model("/proc/device-tree/model");
     std::stringstream ss_model;
@@ -674,6 +694,10 @@ void launch(int runLength, bool useDoubles, bool useTensorCores,
     printf("%s\n", ss_model.str().c_str());
 #else
     system("nvidia-smi -L");
+#endif
+#endif  // __TARGET_NVIDIA
+#if defined(__TARGET_AMD)
+    system("amd-smi list");
 #endif
 
     // Initting A and B with random data


### PR DESCRIPTION
Hi there,

this is early RFC. I added transparent AMD GPU support. I would be very happy about feedback :)

To build for amd, simply run `make TARGET=AMD`. By default, it will still build for NVIDIA of course without any functional changes.

Currently, gpu temp support is not available. While I have though about implementing the same pattern as taken with nvidia-smi, I don't think this is a clean solution. My take here would be to compile amdsmi as a static library and directly link against it. The licenses should be compatible, but correct me if I'm wrong. Also I haven't checked yet whether and how amdsmi handles global state, so there might be a technical issue.

Also I had to comment out some cublas functions. I do not know whether this leads to functional differences, so that should definitely be looked at.

Please let me know what you think :)