### PR TITLE
Add possibility to set make variable COMPUTE in docker build command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 ARG CUDA_VERSION=11.8.0
 ARG IMAGE_DISTRO=ubi8
+ARG COMPUTE=75
 
 FROM nvidia/cuda:${CUDA_VERSION}-devel-${IMAGE_DISTRO} AS builder
 
+ARG COMPUTE=75
+
 WORKDIR /build
 
-COPY . /build/
+COPY compare.cu gpu_burn-drv.cpp Makefile /build/
 
-RUN make
+RUN make COMPUTE=${COMPUTE}
 
 FROM nvidia/cuda:${CUDA_VERSION}-runtime-${IMAGE_DISTRO}
 
@@ -16,4 +19,5 @@ COPY --from=builder /build/compare.ptx /app/
 
 WORKDIR /app
 
-CMD ["./gpu_burn", "60"]
+ENTRYPOINT ["./gpu_burn"]
+CMD ["60"]

--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,4 @@ clean:
 	$(RM) *.ptx *.o gpu_burn
 
 image:
-	docker build --build-arg CUDA_VERSION=${CUDA_VERSION} --build-arg IMAGE_DISTRO=${IMAGE_DISTRO} -t ${IMAGE_NAME} .
+	docker build --build-arg COMPUTE=${COMPUTE} --build-arg CUDA_VERSION=${CUDA_VERSION} --build-arg IMAGE_DISTRO=${IMAGE_DISTRO} -t ${IMAGE_NAME} .

--- a/README.md
+++ b/README.md
@@ -14,10 +14,14 @@ Multi-GPU CUDA stress test
 ```plain
 git clone https://github.com/wilicc/gpu-burn
 cd gpu-burn
-docker build -t gpu_burn .
-docker run --rm --gpus all gpu_burn
+docker build -t gpu-burn .
+docker run --rm --gpus all gpu-burn
 ```
+You can pass build arguments to specify the CUDA version, the compute capability, and base image distro, e.g.:
 
+```plain
+docker build --build-arg CUDA_VERSION=13.0.0 --build-arg COMPUTE=75 --build-arg IMAGE_DISTRO=ubi8 -t gpu-burn .
+```
 ## Binary packages
 
 <https://repology.org/project/gpu-burn/versions>


### PR DESCRIPTION
- In README harmonize image name to executable name
- Add COMPUTE var to `make image` target too
- In Dockerfile copy just the needed files, so that cache is less often invalidated
- Add ENTRYPOINT and CMD to add the possibility to pass arguments to the binary