### PR TITLE
Allow compare kernel to be built as cubin or ptx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ gpu_burn-drv\.o
 
 compare\.ptx
 
+compare\.cubin
+
 gpu_burn

--- a/Makefile
+++ b/Makefile
@@ -30,25 +30,38 @@ COMPUTE      ?= 75
 CUDA_VERSION ?= 11.8.0
 IMAGE_DISTRO ?= ubi8
 
+COMPARE_FORMAT ?= ptx
+
+ifeq ($(COMPARE_FORMAT),cubin)
+NVCC_ARCH      = sm_$(subst .,,${COMPUTE})
+else
+NVCC_ARCH      = compute_$(subst .,,${COMPUTE})
+endif
+
 override NVCCFLAGS ?=
 override NVCCFLAGS += -I${CUDAPATH}/include
-override NVCCFLAGS += -arch=compute_$(subst .,,${COMPUTE})
+override NVCCFLAGS += -arch=${NVCC_ARCH}
+override NVCCFLAGS += -${COMPARE_FORMAT}
+override CFLAGS    += -DCOMPARE_KERNEL=\"compare.$(COMPARE_FORMAT)\"
 
 IMAGE_NAME ?= gpu-burn
 
-.PHONY: clean
+.PHONY: clean image
 
-gpu_burn: gpu_burn-drv.o compare.ptx
+gpu_burn: gpu_burn-drv.o compare.$(COMPARE_FORMAT)
 	g++ -o $@ $< -O3 ${LDFLAGS}
 
 %.o: %.cpp
 	g++ ${CFLAGS} -c $<
 
 %.ptx: %.cu
-	PATH="${PATH}:${CCPATH}:." ${NVCC} ${NVCCFLAGS} -ptx $< -o $@
+	PATH="${PATH}:${CCPATH}:." ${NVCC} ${NVCCFLAGS} $< -o $@
+
+%.cubin: %.cu
+	PATH="${PATH}:${CCPATH}:." ${NVCC} ${NVCCFLAGS} $< -o $@
 
 clean:
-	$(RM) *.ptx *.o gpu_burn
+	$(RM) *.ptx *.cubin *.o gpu_burn
 
 image:
 	docker build --build-arg CUDA_VERSION=${CUDA_VERSION} --build-arg IMAGE_DISTRO=${IMAGE_DISTRO} -t ${IMAGE_NAME} .

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ CCPATH can be specified to point to a specific gcc (default is
 
 `make CCPATH=/usr/local/bin`
 
+COMPARE_FORMAT can be set to `ptx` (default) or `cubin` to control
+the format of the compare kernel binary:
+
+`make COMPARE_FORMAT=cubin`
+
 CUDA_VERSION and IMAGE_DISTRO can be used to override the base
 images used when building the Docker `image` target, while IMAGE_NAME
 can be set to change the resulting image tag:

--- a/gpu_burn-drv.cpp
+++ b/gpu_burn-drv.cpp
@@ -30,7 +30,9 @@
 // Matrices are SIZE*SIZE..  POT should be efficiently implemented in CUBLAS
 #define SIZE 8192ul
 #define USEMEM 0.9 // Try to allocate 90% of memory
+#ifndef COMPARE_KERNEL
 #define COMPARE_KERNEL "compare.ptx"
+#endif
 
 // Used to report op/s, measured through Visual Profiler, CUBLAS from CUDA 7.5
 // (Seems that they indeed take the naive dim^3 approach)


### PR DESCRIPTION
Could help to build and run app in case of newer cuda toolkit and old nvidia driver. https://github.com/wilicc/gpu-burn/issues/145