### PR TITLE
feat: support multiple capabilities with fatbin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN make
 FROM nvidia/cuda:${CUDA_VERSION}-runtime-${IMAGE_DISTRO}
 
 COPY --from=builder /build/gpu_burn /app/
-COPY --from=builder /build/compare.ptx /app/
+COPY --from=builder /build/compare.fatbin /app/
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -32,23 +32,25 @@ IMAGE_DISTRO ?= ubi8
 
 override NVCCFLAGS ?=
 override NVCCFLAGS += -I${CUDAPATH}/include
+ifneq ($(strip $(COMPUTE)),)
 override NVCCFLAGS += -arch=compute_$(subst .,,${COMPUTE})
+endif
 
 IMAGE_NAME ?= gpu-burn
 
 .PHONY: clean
 
-gpu_burn: gpu_burn-drv.o compare.ptx
+gpu_burn: gpu_burn-drv.o compare.fatbin
 	g++ -o $@ $< -O3 ${LDFLAGS}
 
 %.o: %.cpp
 	g++ ${CFLAGS} -c $<
 
-%.ptx: %.cu
-	PATH="${PATH}:${CCPATH}:." ${NVCC} ${NVCCFLAGS} -ptx $< -o $@
+%.fatbin: %.cu
+	PATH="${PATH}:${CCPATH}:." ${NVCC} ${NVCCFLAGS} -fatbin $< -o $@
 
 clean:
-	$(RM) *.ptx *.o gpu_burn
+	$(RM) *.fatbin *.o gpu_burn
 
 image:
 	docker build --build-arg CUDA_VERSION=${CUDA_VERSION} --build-arg IMAGE_DISTRO=${IMAGE_DISTRO} -t ${IMAGE_NAME} .

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ To override this with a different value:
 
 `make COMPUTE=<compute capability value>`
 
+`COMPUTE` selects a single virtual architecture for the default `-arch`
+flag.  For a fat binary targeting multiple architectures, or to opt into
+architecture-conditional (`sm_90a`) or family-specific (`compute_100f`)
+features, set `COMPUTE=` to suppress the default and drive the build
+entirely from `-gencode` flags via `NVCCFLAGS`:
+
+`make COMPUTE= NVCCFLAGS='-gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_90,code=sm_90'`
+
 CFLAGS can be added when invoking make to add to the default
 list of compiler flags:
 

--- a/gpu-burn.8
+++ b/gpu-burn.8
@@ -19,7 +19,7 @@ GPU Burn
 .br
 \fB\-i\fR N    Execute only on GPU N
 .br
-\fB\-c\fR FILE Use FILE as compare kernel.  Default is compare.ptx
+\fB\-c\fR FILE Use FILE as compare kernel.  Default is compare.fatbin
 .br
 \fB\-stts\fR T Set timeout threshold to T seconds for using SIGTERM to abort child processes before using SIGKILL.  Default is 30
 .br

--- a/gpu_burn-drv.cpp
+++ b/gpu_burn-drv.cpp
@@ -30,7 +30,7 @@
 // Matrices are SIZE*SIZE..  POT should be efficiently implemented in CUBLAS
 #define SIZE 8192ul
 #define USEMEM 0.9 // Try to allocate 90% of memory
-#define COMPARE_KERNEL "compare.ptx"
+#define COMPARE_KERNEL "compare.fatbin"
 
 // Used to report op/s, measured through Visual Profiler, CUBLAS from CUDA 7.5
 // (Seems that they indeed take the naive dim^3 approach)


### PR DESCRIPTION
> [!IMPORTANT]
> This PR was made with the assistance of AI tooling (Claude Opus 4.7, specifically).

In Nixpkgs, users are able to build for multiple CUDA capabilities simultaneously. That breaks when building gpu-burn, since the current `COMPUTE` paradigm forces a single capability/feature set.

This PR switches from PTX to fatbin so the result can run on the requested capabilities without needing to JIT the PTX.